### PR TITLE
Update README before release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 
 <div align="center">
-  <a href="https://github.com/reeflective/console">
-    <img alt="" src="" width="600">
-  </a>
   <br> <h1> Console </h1>
 
   <p>  Closed-loop application library for Cobra commands  </p>
-  <p>  (Menus, oh-my-posh prompts, bells and whistles, easy to use)  </p>
+  <p>  (ready-to-use menus, prompts, completions, and more)  </p>
 </div>
 
 
@@ -58,9 +55,9 @@ the various features below almost for free.
 - Bind handlers to special interrupt errors (eg. `CtrlC`/`CtrlD`), per menu.
 
 ### Shell interface
-- Shell interface is powered by a [readline](https://github.com/reeflective/readline) instance.
+- Shell is powered by a [readline](https://github.com/reeflective/readline) instance, with full `inputrc` support and extended functionality.
 - All features of readline are supported in the console. It also allows the console to give:
-- Configurable bind keymaps, with live reload and sane defaults, and system-wide configuration.
+- Configurable bind keymaps, commands and options, sane defaults, and per-application configuration.
 - Out-of-the-box, advanced completions for commands, flags, positional and flag arguments.
 - Provided by readline and [carapace](https://github.com/rsteube/carapace): automatic usage & validation command/flags/args hints.
 - Syntax highlighting for commands (might be extended in the future).
@@ -97,6 +94,7 @@ is also available in the [wiki](https://github.com/reeflective/console/wiki):
 The library is in a pre-release candidate status:
 - Although quite simple and small, it has not been tested heavily.
 - There are probably some features/improvements to be made.
+- The API is quite stable. It is unlikely to change much in future versions.
 
 Please open a PR or an issue if you wish to bring enhancements to it. 
 Other contributions, as well as bug fixes and reviews are also welcome.


### PR DESCRIPTION
- Fixes and enhancements
- Enhancements to runner/async log logic
- Rename some functions
- Override default completion color styles
- Cleanup and fixes to completion code
- Update readline dependency to latest release
- Update README and some comments
- Add .gitignore
- Cleanup to completer code
- Cleanup to running code
- Modify RunCommand()
- Update README
- Enhance example application
- Tidy go mod and add new commands to example
- Mute some stuff
- Try to implement safer concurrent command runs
- Better error handling for hooks, cleaned run code.
- Further cleanup
- Fix interrupt errors matching
- Update go version for Go workflows
- Update Go version workflows
- Update README
