### PR TITLE
dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ is also available in the [wiki](https://github.com/reeflective/console/wiki):
 ![console](https://github.com/reeflective/console/blob/assets/console.gif)
 
 
-## Status
+## Status 
 
 The library is in a pre-release candidate status:
 - Although quite simple and small, it has not been tested heavily.
@@ -100,3 +100,13 @@ The library is in a pre-release candidate status:
 Please open a PR or an issue if you wish to bring enhancements to it. 
 Other contributions, as well as bug fixes and reviews are also welcome.
 
+
+## Possible Improvements
+
+The following is a currently moving list of possible enhancements to be made in order to reach `v1.0`:
+- [ ] Ensure to the best extent possible a thread-safe access to the command API.
+- [ ] Clearer integration/alignment of the various I/O references between readline and commands.
+- [ ] Clearer and sane model for asynchronous control/cancel of commands.
+- [ ] Allow users to run the console command trees in one-exec style, with identical behavior.
+- [ ] Test suite for most important or risky code paths.
+- [ ] Set of helper functions for application-related directories.

--- a/command.go
+++ b/command.go
@@ -1,8 +1,6 @@
 package console
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 )
 
@@ -74,39 +72,4 @@ next:
 	}
 
 	c.filters = updated
-}
-
-func (c *Console) isFiltered(cmd *cobra.Command) (bool, []string) {
-	if cmd.Annotations == nil {
-		return false, nil
-	}
-
-	// Get the filters on the command
-	filterStr := cmd.Annotations[CommandFilterKey]
-	var filters []string
-
-	for _, cmdFilter := range strings.Split(filterStr, ",") {
-		for _, filter := range c.filters {
-			if cmdFilter != "" && cmdFilter == filter {
-				filters = append(filters, cmdFilter)
-			}
-		}
-	}
-
-	return len(filters) > 0, filters
-}
-
-// hide commands that are filtered so that they are not
-// shown in the help strings or proposed as completions.
-func (c *Console) hideFilteredCommands(root *cobra.Command) {
-	for _, cmd := range root.Commands() {
-		// Don't override commands if they are already hidden
-		if cmd.Hidden {
-			continue
-		}
-
-		if filtered, _ := c.isFiltered(cmd); filtered {
-			cmd.Hidden = true
-		}
-	}
 }

--- a/commands/readline/bind.go
+++ b/commands/readline/bind.go
@@ -6,10 +6,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/reeflective/readline"
-	"github.com/reeflective/readline/inputrc"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
+
+	"github.com/reeflective/readline"
+	"github.com/reeflective/readline/inputrc"
 )
 
 // Bind returns a command named `bind`, for manipulating readline keymaps and bindings.

--- a/commands/readline/commands.go
+++ b/commands/readline/commands.go
@@ -1,8 +1,9 @@
 package readline
 
 import (
-	"github.com/reeflective/readline"
 	"github.com/spf13/cobra"
+
+	"github.com/reeflective/readline"
 )
 
 // Commands returns a command named `readline`, with subcommands dedicated

--- a/commands/readline/completers.go
+++ b/commands/readline/completers.go
@@ -21,10 +21,11 @@ package readline
 import (
 	"fmt"
 
-	"github.com/reeflective/readline"
-	"github.com/reeflective/readline/inputrc"
 	"github.com/rsteube/carapace"
 	"github.com/spf13/cobra"
+
+	"github.com/reeflective/readline"
+	"github.com/reeflective/readline/inputrc"
 )
 
 func completeKeymaps(sh *readline.Shell, _ *cobra.Command) carapace.Action {

--- a/commands/readline/export.go
+++ b/commands/readline/export.go
@@ -23,9 +23,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/reeflective/readline"
 	"github.com/reeflective/readline/inputrc"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/commands/readline/set.go
+++ b/commands/readline/set.go
@@ -5,13 +5,14 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/reeflective/readline"
-	"github.com/reeflective/readline/inputrc"
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace/pkg/style"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
+
+	"github.com/reeflective/readline"
+	"github.com/reeflective/readline/inputrc"
 )
 
 var (

--- a/console.go
+++ b/console.go
@@ -136,11 +136,12 @@ func (c *Console) Menu(name string) *Menu {
 // that belong to this new menu. If the menu is invalid, i.e that no commands
 // are bound to this menu name, the current menu is kept.
 func (c *Console) SwitchMenu(menu string) {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
+	c.mutex.Lock()
+	target, found := c.menus[menu]
+	c.mutex.Unlock()
 
-	// Only switch if the target menu was found.
-	if target, found := c.menus[menu]; found && target != nil {
+	if found && target != nil {
+		// Only switch if the target menu was found.
 		current := c.activeMenu()
 		if current != nil && target == current {
 			return

--- a/menu.go
+++ b/menu.go
@@ -197,64 +197,6 @@ func (m *Menu) SetErrFilteredCommandTemplate(s string) {
 	m.errFilteredTemplate = s
 }
 
-func (m *Menu) errorFilteredCommandTemplate(filters []string) string {
-	if m.errFilteredTemplate != "" {
-		return m.errFilteredTemplate
-	}
-
-	return `Command {{.Name}} is unavailable, filtered by:
-{{range $filters}}
-    {{.}} 
-{{end}}
-    `
-}
-
-// tmpl executes the given template text on data, writing the result to w.
-func tmpl(w io.Writer, text string, data interface{}) error {
-	t := template.New("top")
-	t.Funcs(templateFuncs)
-	template.Must(t.Parse(text))
-	return t.Execute(w, data)
-}
-
-var templateFuncs = template.FuncMap{
-	"trim": strings.TrimSpace,
-	// "trimRightSpace":          trimRightSpace,
-	// "trimTrailingWhitespaces": trimRightSpace,
-	// "appendIfNotPresent":      appendIfNotPresent,
-	// "rpad":                    rpad,
-	// "gt":                      Gt,
-	// "eq":                      Eq,
-}
-
-// AddTemplateFunc adds a template function that's available to Usage and Help
-// template generation.
-func AddTemplateFunc(name string, tmplFunc interface{}) {
-	templateFuncs[name] = tmplFunc
-}
-
-// AddTemplateFuncs adds multiple template functions that are available to Usage and
-// Help template generation.
-func AddTemplateFuncs(tmplFuncs template.FuncMap) {
-	for k, v := range tmplFuncs {
-		templateFuncs[k] = v
-	}
-}
-
-func (m *Menu) reset() {
-	if m.cmds != nil {
-		m.Command = m.cmds()
-	}
-
-	if m.Command == nil {
-		m.Command = &cobra.Command{
-			Annotations: make(map[string]string),
-		}
-	}
-
-	m.SilenceUsage = true
-}
-
 // resetPreRun is called before each new read line loop and before arbitrary RunCommand() calls.
 // This function is responsible for resetting the menu state to a clean state, regenerating the
 // menu commands, and ensuring that the correct prompt is bound to the shell.
@@ -303,4 +245,34 @@ func (m *Menu) defaultHistoryName() string {
 	}
 
 	return fmt.Sprintf("local history%s", name)
+}
+
+func (m *Menu) errorFilteredCommandTemplate(filters []string) string {
+	if m.errFilteredTemplate != "" {
+		return m.errFilteredTemplate
+	}
+
+	return `Command {{.Name}} is unavailable, filtered by:
+{{range $filters}}
+    {{.}} 
+{{end}}
+    `
+}
+
+// tmpl executes the given template text on data, writing the result to w.
+func tmpl(w io.Writer, text string, data interface{}) error {
+	t := template.New("top")
+	t.Funcs(templateFuncs)
+	template.Must(t.Parse(text))
+	return t.Execute(w, data)
+}
+
+var templateFuncs = template.FuncMap{
+	"trim": strings.TrimSpace,
+	// "trimRightSpace":          trimRightSpace,
+	// "trimTrailingWhitespaces": trimRightSpace,
+	// "appendIfNotPresent":      appendIfNotPresent,
+	// "rpad":                    rpad,
+	// "gt":                      Gt,
+	// "eq":                      Eq,
 }

--- a/run.go
+++ b/run.go
@@ -83,7 +83,9 @@ func (c *Console) Start() error {
 		// the library user is responsible for setting
 		// the cobra behavior.
 		// If it's an interrupt, we take care of it.
-		c.execute(menu, args, false)
+		if err := c.execute(menu, args, false); err != nil {
+			fmt.Println(err)
+		}
 	}
 }
 
@@ -171,8 +173,8 @@ func (c *Console) execute(menu *Menu, args []string, async bool) (err error) {
 	// Find the target command: if this command is filtered, don't run it.
 	target, _, _ := cmd.Find(args)
 
-	if filters := menu.CheckCommandFiltered(target); len(filters) > 0 {
-		return menu.displayFilteredError(target, filters)
+	if err := menu.ErrUnavailableCommand(target); err != nil {
+		return err
 	}
 
 	// Console-wide pre-run hooks, cannot.

--- a/run.go
+++ b/run.go
@@ -251,12 +251,6 @@ func (c *Console) loadActiveHistories() {
 	}
 }
 
-func (c *Console) runAll(hooks []func()) {
-	for _, hook := range hooks {
-		hook()
-	}
-}
-
 func (c *Console) runAllE(hooks []func() error) error {
 	for _, hook := range hooks {
 		if err := hook(); err != nil {

--- a/run.go
+++ b/run.go
@@ -171,12 +171,8 @@ func (c *Console) execute(menu *Menu, args []string, async bool) (err error) {
 	// Find the target command: if this command is filtered, don't run it.
 	target, _, _ := cmd.Find(args)
 
-	if filtered, filters := menu.CheckCommandFiltered(target); filtered {
-		err := tmpl(cmd.OutOrStdout(), menu.errorFilteredCommandTemplate(filters), c)
-		if err != nil {
-			cmd.PrintErrln(err)
-		}
-		return err
+	if filters := menu.CheckCommandFiltered(target); len(filters) > 0 {
+		return menu.displayFilteredError(target, filters)
 	}
 
 	// Console-wide pre-run hooks, cannot.

--- a/run.go
+++ b/run.go
@@ -171,7 +171,7 @@ func (c *Console) execute(menu *Menu, args []string, async bool) (err error) {
 	// Find the target command: if this command is filtered, don't run it.
 	target, _, _ := cmd.Find(args)
 
-	if filtered, filters := c.isFiltered(target); filtered {
+	if filtered, filters := menu.CheckCommandFiltered(target); filtered {
 		err := tmpl(cmd.OutOrStdout(), menu.errorFilteredCommandTemplate(filters), c)
 		if err != nil {
 			cmd.PrintErrln(err)
@@ -234,13 +234,13 @@ func (c *Console) executeCommand(cmd *cobra.Command, cancel context.CancelCauseF
 // unlike for classic CLI usage when the program will print its usage string.
 // We simply remove any RunE from the root command, so that nothing is
 // printed/executed by default. Pre/Post runs are still used if any.
-// func (c *Console) ensureNoRootRunner() {
-// 	if c.activeMenu().Command != nil {
-// 		c.activeMenu().RunE = func(cmd *cobra.Command, args []string) error {
-// 			return nil
-// 		}
-// 	}
-// }
+func (c *Console) ensureNoRootRunner() {
+	if c.activeMenu().Command != nil {
+		c.activeMenu().RunE = func(cmd *cobra.Command, args []string) error {
+			return nil
+		}
+	}
+}
 
 func (c *Console) loadActiveHistories() {
 	c.shell.History.Delete()

--- a/run.go
+++ b/run.go
@@ -200,7 +200,10 @@ func (c *Console) execute(menu *Menu, args []string, async bool) (err error) {
 	// Wait for the command to finish, or for an OS signal to be caught.
 	select {
 	case <-ctx.Done():
-		err = ctx.Err()
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			err = ctx.Err()
+		}
+
 	case signal := <-sigchan:
 		cancel(errors.New(signal.String()))
 		menu.handleInterrupt(errors.New(signal.String()))

--- a/tab-completer.go
+++ b/tab-completer.go
@@ -28,8 +28,16 @@ func (c *Console) complete(line []rune, pos int) readline.Completions {
 	// (we currently need those two dummies for avoiding a panic).
 	args = append([]string{"examples", "_carapace"}, args...)
 
+	// Regenerate a new instance of the commands.
+	cmd := menu.Command
+	if menu.cmds != nil {
+		cmd = menu.cmds()
+	}
+
+	c.hideFilteredCommands(cmd)
+
 	// Call the completer with our current command context.
-	values, meta := carapace.Complete(menu.Command, args, c.completeCommands(menu))
+	values, meta := carapace.Complete(cmd, args, c.completeCommands(menu))
 
 	// Tranfer all completion results to our readline shell completions.
 	raw := make([]readline.Completion, len(values))
@@ -118,12 +126,13 @@ func sanitizeArgs(rbuffer []rune, args []string) (sanitized []string) {
 // Regenerate commands and apply any filters.
 func (c *Console) completeCommands(menu *Menu) func() {
 	commands := func() {
-		cmd := menu.Command
-		if menu.cmds != nil {
-			cmd = menu.cmds()
-		}
+		// cmd := menu.Command
+		// if menu.cmds != nil {
+		// 	cmd = menu.cmds()
+		// }
 
-		c.hideFilteredCommands(cmd)
+		menu.resetPreRun()
+		c.hideFilteredCommands(menu.Command)
 	}
 
 	return commands

--- a/tab-completer.go
+++ b/tab-completer.go
@@ -118,8 +118,12 @@ func sanitizeArgs(rbuffer []rune, args []string) (sanitized []string) {
 // Regenerate commands and apply any filters.
 func (c *Console) completeCommands(menu *Menu) func() {
 	commands := func() {
-		menu.ResetCommands()
-		c.hideFilteredCommands()
+		cmd := menu.Command
+		if menu.cmds != nil {
+			cmd = menu.cmds()
+		}
+
+		c.hideFilteredCommands(cmd)
 	}
 
 	return commands

--- a/tab-completer.go
+++ b/tab-completer.go
@@ -29,15 +29,10 @@ func (c *Console) complete(line []rune, pos int) readline.Completions {
 	args = append([]string{"examples", "_carapace"}, args...)
 
 	// Regenerate a new instance of the commands.
-	cmd := menu.Command
-	if menu.cmds != nil {
-		cmd = menu.cmds()
-	}
-
-	c.hideFilteredCommands(cmd)
+	// menu.hideFilteredCommands(cmd)
 
 	// Call the completer with our current command context.
-	values, meta := carapace.Complete(cmd, args, c.completeCommands(menu))
+	values, meta := carapace.Complete(menu.Command, args, c.completeCommands(menu))
 
 	// Tranfer all completion results to our readline shell completions.
 	raw := make([]readline.Completion, len(values))
@@ -126,13 +121,13 @@ func sanitizeArgs(rbuffer []rune, args []string) (sanitized []string) {
 // Regenerate commands and apply any filters.
 func (c *Console) completeCommands(menu *Menu) func() {
 	commands := func() {
-		// cmd := menu.Command
-		// if menu.cmds != nil {
-		// 	cmd = menu.cmds()
-		// }
+		cmd := menu.Command
+		if menu.cmds != nil {
+			cmd = menu.cmds()
+		}
 
 		menu.resetPreRun()
-		c.hideFilteredCommands(menu.Command)
+		menu.hideFilteredCommands(cmd)
 	}
 
 	return commands


### PR DESCRIPTION
- Enhance bind command with regard to aliased keymaps
- Update dependencies
- Update deps
- Fix go.mod replace
- Restructure readline bind --flags logic
- Add comps to var set
- Fmt
- Print variables/binds in conditionals
- Properly refactor config export outputs
- Continue refactor with binds
- Add macro stuff to previous commits
- Renaming
- Finish readline command
- Fix stupid
- Fix stupid again
- Fix conc access, enhance stuffs
- Better display for unavailable commands
- Better API for filters checks
- Don't return context.Canceled errors
- Clean
