### PR TITLE
dev

### DIFF
--- a/menu.go
+++ b/menu.go
@@ -322,8 +322,7 @@ func (m *Menu) errorFilteredCommandTemplate(filters []string) string {
 	}
 
 	return `Command {{.cmd.Name}} is only available for: {{range .filters }}
-    - {{.}} 
-{{end}}`
+    - {{.}} {{end}}`
 }
 
 // tmpl executes the given template text on data, writing the result to w.

--- a/run.go
+++ b/run.go
@@ -116,7 +116,7 @@ func (c *Console) ExecuteOnce() error {
 	// which may modify the input line args.
 	args, err := c.runLineHooks(os.Args)
 	if err != nil {
-		return fmt.Errorf("line error: %s\n", err.Error())
+		return fmt.Errorf("line error: %s", err.Error())
 	}
 
 	// Run all pre-run hooks and the command itself
@@ -229,18 +229,6 @@ func (c *Console) executeCommand(cmd *cobra.Command, cancel context.CancelCauseF
 
 	// Command successfully executed, cancel the context.
 	cancel(nil)
-}
-
-// Generally, an empty command entered should just print a new prompt,
-// unlike for classic CLI usage when the program will print its usage string.
-// We simply remove any RunE from the root command, so that nothing is
-// printed/executed by default. Pre/Post runs are still used if any.
-func (c *Console) ensureNoRootRunner() {
-	if c.activeMenu().Command != nil {
-		c.activeMenu().RunE = func(cmd *cobra.Command, args []string) error {
-			return nil
-		}
-	}
 }
 
 func (c *Console) loadActiveHistories() {


### PR DESCRIPTION
- Enhance bind command with regard to aliased keymaps
- Update dependencies
- Update deps
- Fix go.mod replace
- Restructure readline bind --flags logic
- Add comps to var set
- Fmt
- Print variables/binds in conditionals
- Properly refactor config export outputs
- Continue refactor with binds
- Add macro stuff to previous commits
- Renaming
- Finish readline command
- Fix stupid
- Fix stupid again
- Fix conc access, enhance stuffs
- Better display for unavailable commands
- Better API for filters checks
- Don't return context.Canceled errors
- Clean
- Remove  useless code
