### PR TITLE
Improved syntax highlighting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pygrum/console
+module github.com/reeflective/console
 
 go 1.21
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/reeflective/console
+module github.com/pygrum/console
 
 go 1.21
 

--- a/highlighter.go
+++ b/highlighter.go
@@ -71,7 +71,8 @@ func (c *Console) highlightCommand(done, args []string, _ *cobra.Command) ([]str
 
 	// Highlight the root command when found, or any of its aliases.
 	for _, cmd := range c.activeMenu().Commands() {
-		cmdFound := cmd.Use == strings.TrimSpace(args[0])
+		// Change 1: Highlight based on first arg in usage rather than the entire usage itself
+		cmdFound := strings.Split(cmd.Use, " ")[0] == strings.TrimSpace(args[0])
 
 		for _, alias := range cmd.Aliases {
 			if alias == strings.TrimSpace(args[0]) {


### PR DESCRIPTION
### Changes
Previously, Console used the cobra.Command usage rather than the operand for syntax highlighting. This prevented highlights from being made with commands that had usages with positional arguments, e.g. `exit [code]`. 

This change now allows highlighting for such commands, and doesn't affect commands with single word usages - they still highlight. 

Example / test script:
```go
package main

import (
        "os"
        "fmt"
        "github.com/reeflective/console"
        "github.com/spf13/cobra"
)

func cmds() *cobra.Command {
        rootCmd := &cobra.Command{}
        exitCmd := &cobra.Command{
                Use: "exit [code]",
                Short: "exit the application",
                Run: func(cmd *cobra.Command, args []string) {
                        os.Exit(0)
                },
        }
        hwCmd := &cobra.Command{
                Use: "hw",
                Short: "print hello world",
                Run: func(cmd *cobra.Command, args []string) {
                        fmt.Println("Hello, World!")
                },
        }
        rootCmd.AddCommand(exitCmd, hwCmd)
        return rootCmd
}

func main(){
        app := console.New("app")
        menu := app.ActiveMenu()
        menu.SetCommands(cmds)
        app.Start()
}
```