### PR TITLE
Add console.ErrCtrC referenced in documentation

### DIFF
--- a/interrupt.go
+++ b/interrupt.go
@@ -1,5 +1,12 @@
 package console
 
+import (
+	"errors"
+	"os"
+)
+
+var ErrCtrlC = errors.New(os.Interrupt.String())
+
 // AddInterrupt registers a handler to run when the console receives a given
 // interrupt error from the underlying readline shell. Mainly two interrupt
 // signals are concerned: io.EOF (returned when pressing CtrlD), and console.ErrCtrlC.


### PR DESCRIPTION
The [documentation](https://pkg.go.dev/github.com/reeflective/console#Menu.AddInterrupt) mentions a `console.ErrCtrlC` for checking interrupts. However I noticed that said Err does not exist in console package.

This PR adds it in.

Alternatively, could consider modifying the documentation to give an example of how to detect Ctrl+C (i.e. new error from `os.Interrupt.String()`)