### PR TITLE
feat: newline when empty flag

### DIFF
--- a/console.go
+++ b/console.go
@@ -33,6 +33,17 @@ type Console struct {
 	// know how to handle it in all situations.
 	NewlineAfter bool
 
+	// Leave empty lines with NewlineBefore and NewlineAfter, even if the provided input was empty.
+	// Empty characters are defined as any number of spaces and tabs. The 'empty' character set
+	// can be changed by modifying Console.EmptyChars
+	// This field is false by default.
+	NewlineWhenEmpty bool
+
+	// Characters that are used to determine whether an input line was empty. If a line is not entirely
+	// made up by any of these characters, then it is not considered empty. The default characters
+	// are ' ' and '\t'.
+	EmptyChars []rune
+
 	// PreReadlineHooks - All the functions in this list will be executed,
 	// in their respective orders, before the console starts reading
 	// any user input (ie, before redrawing the prompt).
@@ -89,6 +100,8 @@ func New(app string) *Console {
 	console.shell.Completer = console.complete
 	console.defaultStyleConfig()
 
+	// Defaults
+	console.EmptyChars = []rune{' ', '\t'}
 	return console
 }
 

--- a/line.go
+++ b/line.go
@@ -267,3 +267,14 @@ func trimSpacesMatch(remain []string) (trimmed []string) {
 
 	return
 }
+
+func (c *Console) lineEmpty(line string) bool {
+	empty := true
+	for _, r := range line {
+		if !strings.ContainsRune(string(c.EmptyChars), r) {
+			empty = false
+			break
+		}
+	}
+	return empty
+}

--- a/run.go
+++ b/run.go
@@ -24,7 +24,7 @@ func (c *Console) Start() error {
 	}
 
 	firstRead := true // leave space between logo and first prompt on first read without fail, if NewlineAfter is set.
-	lastLine := "_"   // used to check if last read line is empty.
+	lastLine := ""    // used to check if last read line is empty.
 
 	for {
 		// Identical to printing it at the end of the loop, and

--- a/run.go
+++ b/run.go
@@ -23,11 +23,27 @@ func (c *Console) Start() error {
 		c.printLogo(c)
 	}
 
+	firstRead := true // leave space between logo and first prompt on first read without fail, if NewlineAfter is set.
+	lastLine := "_"   // used to check if last read line is empty.
+
 	for {
 		// Identical to printing it at the end of the loop, and
 		// leaves some space between the logo and the first prompt.
+
+		// If NewlineAfter is set but NewlineWhenEmpty is not set, we do a check to see
+		// if the last line was empty. If it wasn't, then we can print.
 		if c.NewlineAfter {
-			fmt.Println()
+			if !c.NewlineWhenEmpty && !firstRead {
+				// Print on the condition that the last input wasn't empty.
+				if !c.lineEmpty(lastLine) {
+					fmt.Println(lastLine)
+				}
+			} else {
+				fmt.Println()
+			}
+		}
+		if firstRead {
+			firstRead = false
 		}
 
 		// Always ensure we work with the active menu, with freshly
@@ -44,9 +60,14 @@ func (c *Console) Start() error {
 
 		// Block and read user input.
 		line, err := c.shell.Readline()
-
 		if c.NewlineBefore {
-			fmt.Println()
+			if !c.NewlineWhenEmpty {
+				if !c.lineEmpty(lastLine) {
+					fmt.Println(lastLine)
+				}
+			} else {
+				fmt.Println()
+			}
 		}
 
 		if err != nil {
@@ -86,6 +107,7 @@ func (c *Console) Start() error {
 		if err := c.execute(menu, args, false); err != nil {
 			fmt.Println(err)
 		}
+		lastLine = line
 	}
 }
 

--- a/run.go
+++ b/run.go
@@ -42,9 +42,6 @@ func (c *Console) Start() error {
 				fmt.Println()
 			}
 		}
-		if firstRead {
-			firstRead = false
-		}
 
 		// Always ensure we work with the active menu, with freshly
 		// generated commands, bound prompts and some other things.
@@ -61,7 +58,7 @@ func (c *Console) Start() error {
 		// Block and read user input.
 		line, err := c.shell.Readline()
 		if c.NewlineBefore {
-			if !c.NewlineWhenEmpty {
+			if !c.NewlineWhenEmpty && !firstRead {
 				if !c.lineEmpty(lastLine) {
 					fmt.Println()
 				}
@@ -106,6 +103,9 @@ func (c *Console) Start() error {
 		// If it's an interrupt, we take care of it.
 		if err := c.execute(menu, args, false); err != nil {
 			fmt.Println(err)
+		}
+		if firstRead {
+			firstRead = false
 		}
 		lastLine = line
 	}

--- a/run.go
+++ b/run.go
@@ -36,7 +36,7 @@ func (c *Console) Start() error {
 			if !c.NewlineWhenEmpty && !firstRead {
 				// Print on the condition that the last input wasn't empty.
 				if !c.lineEmpty(lastLine) {
-					fmt.Println(lastLine)
+					fmt.Println()
 				}
 			} else {
 				fmt.Println()
@@ -63,7 +63,7 @@ func (c *Console) Start() error {
 		if c.NewlineBefore {
 			if !c.NewlineWhenEmpty {
 				if !c.lineEmpty(lastLine) {
-					fmt.Println(lastLine)
+					fmt.Println()
 				}
 			} else {
 				fmt.Println()


### PR DESCRIPTION
# Feature description
Added `NewlineWhenEmpty` flag to Console object, which prints newlines before and after user input, even if the user input was  empty. This was originally default behaviour, which lead to unwanted gaps when hitting enter, Ctrl-C, or any 'empty' character.

Hitting enter with `NewlineWhenEmpty` set:
```
➜  go run main.go

app > 


app > 


app > 
```

Hitting enter without `NewlineWhenEmpty` set (default):
```
➜  testenv go run main.go                                  

app > 
app > 
app > 
app > 
```

In addition to `NewlineWhenEmpty`, console field `EmptyChars` is created to modify which characters a line must be made up of to be considered empty. By default these are:
- tab character
- space character

and of course, no input at all.