### PR TITLE
NewlineBefore and NewlineAfter bug 

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -17,7 +17,7 @@ func main() {
 	app := console.New("example")
 
 	// Global Setup ------------------------------------------------- //
-	app.NewlineBefore = true
+	app.NewlineBefore = false
 	app.NewlineAfter = true
 
 	app.SetPrintLogo(func(_ *console.Console) {

--- a/run.go
+++ b/run.go
@@ -33,6 +33,8 @@ func (c *Console) StartContext(ctx context.Context) error {
 	lastLine := "" // used to check if last read line is empty.
 
 	for {
+		// Print a newline after the last output if NewlineAfter is true
+		// and the last line was not empty.
 		c.displayPostRun(lastLine)
 
 		// Always ensure we work with the active menu, with freshly
@@ -47,15 +49,10 @@ func (c *Console) StartContext(ctx context.Context) error {
 		}
 
 		// Block and read user input.
-		input , err := c.shell.Readline()
-
-		c.displayPostRun(input)
-
+		input, err := c.shell.Readline()
 		if err != nil {
 			menu.handleInterrupt(err)
-
-			lastLine = input 
-
+			lastLine = input
 			continue
 		}
 
@@ -72,7 +69,7 @@ func (c *Console) StartContext(ctx context.Context) error {
 		}
 
 		if len(args) == 0 {
-			lastLine = input 
+			lastLine = input
 			continue
 		}
 
@@ -84,6 +81,10 @@ func (c *Console) StartContext(ctx context.Context) error {
 			continue
 		}
 
+		// Print a newline before executing the command if NewlineBefore is true
+		// and the last line was not empty.
+		c.displayPreRun(input)
+
 		// Run all pre-run hooks and the command itself
 		// Don't check the error: if its a cobra error,
 		// the library user is responsible for setting
@@ -93,7 +94,7 @@ func (c *Console) StartContext(ctx context.Context) error {
 			menu.ErrorHandler(ExecutionError{newError(err, "")})
 		}
 
-		lastLine = input 
+		lastLine = input
 	}
 }
 


### PR DESCRIPTION
Hi! It looks like `NewlineBefore` and `NewlineAfter` don't work properly.

When `NewlineBefore = false` and `NewlineAfter = true` the expected output is

```
example [main] in github/console/example
> hello
Hello, World!

example [main] in github/console/example
>
```

But currently it is:

```
example [main] in github/console/example
> hello

Hello, World!

example [main] in github/console/example
>
```

I fixed this issue and tested it locally, but it would be great if you could take a look too :)