### PR TITLE
Reset flag state before completion

### DIFF
--- a/completer.go
+++ b/completer.go
@@ -7,6 +7,8 @@ import (
 	"github.com/carapace-sh/carapace/pkg/style"
 	completer "github.com/carapace-sh/carapace/pkg/x"
 	"github.com/reeflective/readline"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/reeflective/console/internal/completion"
 	"github.com/reeflective/console/internal/line"
@@ -22,6 +24,7 @@ func (c *Console) complete(input []rune, pos int) readline.Completions {
 	// Split the line as shell words, only using
 	// what the right buffer (up to the cursor)
 	args, prefixComp, prefixLine := completion.SplitArgs(input, pos)
+	resetCompletionFlagState(menu.Command, args)
 
 	// Prepare arguments for the carapace completer
 	// (we currently need those two dummies for avoiding a panic).
@@ -89,6 +92,84 @@ func (c *Console) complete(input []rune, pos int) readline.Completions {
 	menu.resetCommands()
 
 	return comps
+}
+
+func resetCompletionFlagState(root *cobra.Command, args []string) {
+	if root == nil {
+		return
+	}
+
+	target := findCompletionTarget(root, args)
+	_ = target.LocalFlags()
+	resetCompletionFlagDefaults(target)
+	resetArgsLenAtDash(target)
+}
+
+func resetCompletionFlagDefaults(target *cobra.Command) {
+	if target == nil {
+		return
+	}
+
+	target.Flags().VisitAll(func(flag *pflag.Flag) {
+		flag.Changed = false
+		switch value := flag.Value.(type) {
+		case pflag.SliceValue:
+			var res []string
+			if len(flag.DefValue) > 0 && flag.DefValue != "[]" {
+				res = append(res, flag.DefValue)
+			}
+
+			_ = value.Replace(res)
+		default:
+			_ = flag.Value.Set(flag.DefValue)
+		}
+	})
+}
+
+func resetArgsLenAtDash(target *cobra.Command) {
+	for cmd := target; cmd != nil; cmd = cmd.Parent() {
+		resetFlagSetArgsLenAtDash(cmd.Flags(), cmd.DisplayName())
+		resetFlagSetArgsLenAtDash(cmd.PersistentFlags(), cmd.DisplayName())
+	}
+}
+
+func resetFlagSetArgsLenAtDash(fs *pflag.FlagSet, name string) {
+	if fs == nil {
+		return
+	}
+
+	fs.Init(name, pflag.ContinueOnError)
+}
+
+func findCompletionTarget(root *cobra.Command, args []string) *cobra.Command {
+	cmd := root
+	for _, arg := range args {
+		if arg == "--" || strings.HasPrefix(arg, "-") {
+			break
+		}
+
+		next := findSubcommand(cmd, arg)
+		if next == nil {
+			break
+		}
+		cmd = next
+	}
+
+	return cmd
+}
+
+func findSubcommand(cmd *cobra.Command, name string) *cobra.Command {
+	if cmd == nil {
+		return nil
+	}
+
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == name || sub.HasAlias(name) {
+			return sub
+		}
+	}
+
+	return nil
 }
 
 // justifyCommandComps justifies the descriptions for all commands in all groups

--- a/completer_test.go
+++ b/completer_test.go
@@ -1,0 +1,55 @@
+package console
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCompleteResetsFlagDefaults(t *testing.T) {
+	c := New("test")
+	root := &cobra.Command{Use: "root"}
+	cmd := &cobra.Command{Use: "serve"}
+	cmd.Flags().Bool("verbose", false, "")
+	root.AddCommand(cmd)
+	c.activeMenu().Command = root
+
+	if err := cmd.Flags().Set("verbose", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = c.complete([]rune("serve "), len("serve "))
+
+	flag := cmd.Flags().Lookup("verbose")
+	if flag == nil {
+		t.Fatal("missing verbose flag")
+	}
+	if flag.Changed {
+		t.Fatal("completion did not clear flag Changed state")
+	}
+	if flag.Value.String() != "false" {
+		t.Fatalf("flag value = %q, want false", flag.Value.String())
+	}
+}
+
+func TestCompleteResetsArgsLenAtDash(t *testing.T) {
+	c := New("test")
+	root := &cobra.Command{Use: "root"}
+	cmd := &cobra.Command{Use: "serve"}
+	cmd.Flags().Bool("verbose", false, "")
+	root.AddCommand(cmd)
+	c.activeMenu().Command = root
+
+	if err := cmd.Flags().Parse([]string{"--", "positional"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := cmd.Flags().ArgsLenAtDash(); got < 0 {
+		t.Fatalf("test setup did not set ArgsLenAtDash: %d", got)
+	}
+
+	_ = c.complete([]rune("serve "), len("serve "))
+
+	if got := cmd.Flags().ArgsLenAtDash(); got != -1 {
+		t.Fatalf("ArgsLenAtDash = %d, want -1", got)
+	}
+}


### PR DESCRIPTION
Background

Console completion reuses cobra command trees. Flags parsed by an earlier completion or execution can leave Changed, values, and ArgsLenAtDash state behind, which can influence later completion results for the same command tree.

Approach

- Locate the command being completed from the current input words.
- Reset that command's flag values and Changed state before invoking carapace completion.
- Reset ArgsLenAtDash on the target command and its parents.
- Keep this scoped to the completion path.

Tests

- Added coverage that a previously changed bool flag is restored before completion.
- Added coverage that ArgsLenAtDash is restored after a previous parse containing --.
- Ran go test ./...