### PR TITLE
Expose console command execution

### DIFF
--- a/run.go
+++ b/run.go
@@ -143,6 +143,15 @@ func (m *Menu) RunCommandLine(ctx context.Context, line string) (err error) {
 	return m.RunCommandArgs(ctx, args)
 }
 
+// Execute runs a processed argument vector against a menu command tree.
+//
+// Most callers should prefer Menu.RunCommandArgs, which resets the active menu
+// before execution. Execute is useful for integrations that already prepared a
+// menu and need direct access to the lower-level execution path.
+func (c *Console) Execute(ctx context.Context, menu *Menu, args []string, async bool) error {
+	return c.execute(ctx, menu, args, async)
+}
+
 // execute - The user has entered a command input line, the arguments have been processed:
 // we synchronize a few elements of the console, then pass these arguments to the command
 // parser for execution and error handling.

--- a/run_execute_test.go
+++ b/run_execute_test.go
@@ -1,0 +1,33 @@
+package console
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestConsoleExecuteRunsPreparedMenu(t *testing.T) {
+	c := New("test")
+	menu := c.ActiveMenu()
+
+	var ran bool
+	root := &cobra.Command{Use: "root"}
+	root.AddCommand(&cobra.Command{
+		Use: "run",
+		Run: func(*cobra.Command, []string) {
+			ran = true
+		},
+	})
+	menu.Command = root
+
+	if err := c.Execute(context.Background(), menu, []string{"run"}, false); err != nil {
+		t.Fatal(err)
+	}
+	if !ran {
+		t.Fatal("Execute did not run the target command")
+	}
+	if c.isExecuting.Load() {
+		t.Fatal("Execute left the console marked as executing")
+	}
+}


### PR DESCRIPTION
Background

`Menu.RunCommandArgs` is the normal public entry point for programmatic execution, but it always goes through the active-menu reset flow. Some integrations prepare a menu command tree themselves and need direct access to the lower-level execution path that `StartContext` and `RunCommandArgs` use internally.

Approach

- Add `Console.Execute(ctx, menu, args, async)` as a small public wrapper around the existing internal execution path.
- Keep the existing `execute` implementation and current callers unchanged.
- Document that most callers should continue using `Menu.RunCommandArgs` unless they already prepared a menu.

Tests

- Added a regression test that executes a prepared menu command through `Console.Execute`.
- Verified the target command runs and the console execution flag is cleared afterwards.
- Ran `go test ./...`